### PR TITLE
add Linux build compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 LilyWallet-darwin-x64
 .DS_Store
+release-builds

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "eject": "react-scripts eject",
     "package-mac": "electron-packager . LilyWallet --platform=darwin --arch=x64 --icon=./src/assets/AppIcon.icns --prune=true --out=release-builds --overwrite",
     "dist-mac": "electron-installer-dmg ./release-builds/LilyWallet-darwin-x64/LilyWallet.app LilyWallet-mac-v0.0.01-beta --overwrite",
-    "package-windows": "electron-packager . LilyWallet --platform=win32 --arch=x64 --asar=true --icon=./src/assets/icon_512@2x.png --prune=true --out=release-builds --overwrite"
+    "package-windows": "electron-packager . LilyWallet --platform=win32 --arch=x64 --asar=true --icon=./src/assets/icon_512@2x.png --prune=true --out=release-builds --overwrite",
+    "package-linux": "electron-packager . LilyWallet --platform=linux --arch=x64 --icon=./src/assets/AppIcon.icns --prune=true --out=release-builds --overwrite"
   },
   "dependencies": {
     "axios": "^0.19.2",

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ function createWindow() {
   mainWindow.maximize();
 
   // load production url
-  mainWindow.loadURL(`file://${__dirname}/build/index.html`);
+  mainWindow.loadURL(`file://${__dirname}/../build/index.html`);
   // load dev url
   // mainWindow.loadURL(`http://localhost:3001/`);
 


### PR DESCRIPTION
Building the Electron binary was not supported for Linux. To enable that:

* the path for mainWindow.loadURL had to be fixed, and
* package.json is extended with 'package-linux'

It should now be possible to just compile with:

```sh
$ npm run build
$ npm run package-linux
```