### PR TITLE
Enable testnet transactions and sign all inputs if requiredSigners == 1

### DIFF
--- a/src/pages/Send/TransactionDetails.js
+++ b/src/pages/Send/TransactionDetails.js
@@ -5,15 +5,24 @@ import { ArrowIosForwardOutline } from '@styled-icons/evaicons-outline'
 
 import {
   blockExplorerAPIURL,
+  blockExplorerURL,
   satoshisToBitcoins,
 } from "unchained-bitcoin";
 
-import { Psbt, address } from 'bitcoinjs-lib';
+import { Psbt, address, networks } from 'bitcoinjs-lib';
 
 import { cloneBuffer } from '../../utils/other';
 import { StyledIcon, Button, SidewaysShake } from '../../components';
 
 import { gray, blue, darkGray, white, darkOffWhite, green, darkGreen, lightGray, red, lightRed } from '../../utils/colors';
+
+const getUnchainedNetworkFromBjslibNetwork = (bitcoinJslibNetwork) => {
+  if (bitcoinJslibNetwork === networks.bitcoin) {
+    return 'mainnet';
+  } else {
+    return 'testnet';
+  }
+}
 
 const TransactionDetails = ({ finalPsbt, feeEstimate, outputTotal, recipientAddress, sendAmount, setStep, transactionsMap, signedPsbts, signThreshold, currentBitcoinNetwork, currentBitcoinPrice }) => {
   const [showMoreDetails, setShowMoreDetails] = useState(false);
@@ -33,11 +42,11 @@ const TransactionDetails = ({ finalPsbt, feeEstimate, outputTotal, recipientAddr
 
           psbt.finalizeAllInputs();
 
-          const { data } = await axios.get(blockExplorerAPIURL(`/broadcast?tx=${psbt.extractTransaction().toHex()}`, currentBitcoinNetwork));
+          const { data } = await axios.get(blockExplorerAPIURL(`/broadcast?tx=${psbt.extractTransaction().toHex()}`, getUnchainedNetworkFromBjslibNetwork(currentBitcoinNetwork)));
           setBroadcastedTxId(data);
 
         } else {
-          const { data } = await axios.get(blockExplorerAPIURL(`/broadcast?tx=${signedPsbts[0].extractTransaction().toHex()}`, currentBitcoinNetwork));
+          const { data } = await axios.get(blockExplorerAPIURL(`/broadcast?tx=${signedPsbts[0].extractTransaction().toHex()}`, getUnchainedNetworkFromBjslibNetwork(currentBitcoinNetwork)));
           setBroadcastedTxId(data);
         }
       } catch (e) {
@@ -70,7 +79,7 @@ const TransactionDetails = ({ finalPsbt, feeEstimate, outputTotal, recipientAddr
               )}
             </SendButton>}
 
-            {broadcastedTxId && <ViewTransactionButton href={`https://blockstream.info/tx/${broadcastedTxId}`} target="_blank">View Transaction</ViewTransactionButton>}
+            {broadcastedTxId && <ViewTransactionButton href={blockExplorerURL(`/tx/${broadcastedTxId}`, getUnchainedNetworkFromBjslibNetwork(currentBitcoinNetwork))} target="_blank">View Transaction</ViewTransactionButton>}
             <MoreDetails>
               <span onClick={() => setShowMoreDetails(!showMoreDetails)}>{showMoreDetails ? 'Less' : 'More'} Details ></span>
               <span onClick={() => setStep(0)}>Edit Transaction</span>

--- a/src/pages/Send/index.js
+++ b/src/pages/Send/index.js
@@ -24,9 +24,9 @@ import TransactionDetails from './TransactionDetails';
 import { red, gray, blue, darkGray, white, darkOffWhite, lightGray, lightBlue } from '../../utils/colors';
 import { mobile } from '../../utils/media';
 
-const validateAddress = (recipientAddress) => {
+const validateAddress = (recipientAddress, network) => {
   try {
-    address.toOutputScript(recipientAddress)
+    address.toOutputScript(recipientAddress, network)
     return true
   } catch (e) {
     return false
@@ -179,7 +179,7 @@ const Send = ({ config, currentAccount, setCurrentAccount, loadingDataFromBlocks
       const seed = await mnemonicToSeed(currentAccount.config.mnemonic);
       const root = bip32.fromSeed(seed, currentBitcoinNetwork);
 
-      psbt.signInputHD(0, root);
+      psbt.signAllInputsHD(root);
       psbt.validateSignaturesOfAllInputs();
       psbt.finalizeAllInputs();
 
@@ -190,11 +190,11 @@ const Send = ({ config, currentAccount, setCurrentAccount, loadingDataFromBlocks
   const transactionsMap = createTransactionMapFromTransactionArray(transactions);
 
   const validateAndCreateTransaction = () => {
-    if (!validateAddress(recipientAddress)) {
+    if (!validateAddress(recipientAddress, currentBitcoinNetwork)) {
       setRecipientAddressError(true);
     }
 
-    if (validateAddress(recipientAddress) && recipientAddressError) {
+    if (validateAddress(recipientAddress, currentBitcoinNetwork) && recipientAddressError) {
       setRecipientAddressError(false);
     }
 
@@ -206,7 +206,7 @@ const Send = ({ config, currentAccount, setCurrentAccount, loadingDataFromBlocks
       setSendAmountError(false)
     }
 
-    if (validateAddress(recipientAddress) && sendAmount && satoshisToBitcoins(feeEstimate.plus(currentBalance)).isGreaterThan(sendAmount)) {
+    if (validateAddress(recipientAddress, currentBitcoinNetwork) && sendAmount && satoshisToBitcoins(feeEstimate.plus(currentBalance)).isGreaterThan(sendAmount)) {
       createTransaction(sendAmount, recipientAddress, availableUtxos, transactions)
     }
   }


### PR DESCRIPTION
When I was testing the app, I noticed 1) transactions in testnet are not working 2) if there's only one required signer for a transaction and this transaction has more than one input, it won't work (probably it also would occur in mainnet).

The change in line 182 of src/pages/Send/index.js is relative to inputs signing issue.

The others are relative to transact in testnet.
The change in line 27 of src/pages/Send/index.js  enables the testnet address validation.
The changes in lines 45 and 49 of src/pages/Send/index.js  enable the broadcast on testnet .
The change in line 82 of src/pages/Send/index.js  open the Blockstream explorer url according the network.