### PR TITLE
fixes bug with tx broadcast using block explorer and testnet

### DIFF
--- a/src/pages/Send/TransactionDetails.js
+++ b/src/pages/Send/TransactionDetails.js
@@ -8,7 +8,8 @@ import { useHistory } from "react-router-dom";
 import {
   blockExplorerAPIURL,
   blockExplorerTransactionURL,
-  satoshisToBitcoins
+  satoshisToBitcoins,
+  MAINNET, TESTNET
 } from "unchained-bitcoin";
 
 import { address, Psbt } from 'bitcoinjs-lib';
@@ -71,7 +72,9 @@ const TransactionDetails = ({
       });
       return data;
     } else {
-      const { data } = await axios.get(blockExplorerAPIURL(`/broadcast?tx=${psbt.extractTransaction().toHex()}`, currentBitcoinNetwork));
+      const txBody = psbt.extractTransaction().toHex();
+      const network = currentBitcoinNetwork.bech32 === 'bc' ? MAINNET : TESTNET;
+      const { data } = await axios.post(blockExplorerAPIURL('/tx', network), txBody);
       return data;
     }
   }


### PR DESCRIPTION
This PR solves two issues I found when trying to broadcast a transaction using the block explorer.

1- The block explorer's broadcast address itself seems to have been wrong. Checking at the esplora's [API docs](https://github.com/Blockstream/esplora/blob/master/API.md) one can see there's no `/broadcast` endpoint. Instead a POST to `/tx` is what's required.

2- Bitcoin's Mainnet was always being selected no matter what the `currentBitcoinNetwork` variable was. 