### PR TITLE
Fixes #39, introducing a new tx type called 'moved' used for self transfers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "electron": "electron .",
     "start": "PORT=3001 react-scripts start",
+    "electron-testnet": "TESTNET=true electron .",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -113,6 +114,8 @@
     "electron-installer-dmg": "^3.0.0",
     "electron-packager": "^14.2.1",
     "electron-winstaller": "^4.0.0",
-    "react-app-rewired": "^2.1.6"
+    "mocha": "^8.1.3",
+    "react-app-rewired": "^2.1.6",
+    "rewire": "^5.0.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -213,7 +213,7 @@ function App() {
 
   // fetch/build account data from config file
   useEffect(() => {
-    console.log('useEffect config: ', config)
+
     if (config.wallets.length || config.vaults.length) {
       const initialAccountMap = new Map();
 

--- a/src/components/transactions/TransactionRow.js
+++ b/src/components/transactions/TransactionRow.js
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import moment from 'moment';
 import { VerticalAlignBottom, ArrowUpward } from '@styled-icons/material';
+import { Transfer } from '@styled-icons/boxicons-regular';
 import { StyledIcon } from '../../components';
 import { satoshisToBitcoins } from "unchained-bitcoin";
 
-import { white, offWhite, green, gray, lightBlue } from '../../utils/colors';
+import { white, offWhite, green, gray, red500, lightBlue } from '../../utils/colors';
 
 const TransactionRow = ({ transaction, flat }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -15,6 +16,7 @@ const TransactionRow = ({ transaction, flat }) => {
         <TxTypeIcon flat={flat}>
           {transaction.type === 'received' && <StyledIconModified as={VerticalAlignBottom} size={flat ? 36 : 48} receive={true} />}
           {transaction.type === 'sent' && <StyledIconModified as={ArrowUpward} size={flat ? 36 : 48} />}
+          {transaction.type === 'moved' && <StyledIconModified as={Transfer} size={flat ? 36 : 48} moved={true}/>}
           <TxTypeTextWrapper flat={flat}>
             <TxTypeText>{transaction.type}</TxTypeText>
             <TxTypeTime>{transaction.status.confirmed ? moment.unix(transaction.status.block_time).format('h:mm A') : 'Unconfirmed'}</TxTypeTime>
@@ -62,7 +64,7 @@ const TransactionMoreInfo = styled.div`
 const StyledIconModified = styled(StyledIcon)`
   padding: .5em;
   margin-right: .75em;
-  background: ${ p => p.receive ? green : gray};
+  background: ${ p => p.moved ? gray : (p.receive ? green : red500)};
   border-radius: 50%;
 `;
 

--- a/test/fixtures/serializeTransactions.json
+++ b/test/fixtures/serializeTransactions.json
@@ -1,0 +1,931 @@
+{
+	"original": [
+		{
+			"txid": "5b00f5bd218d09071d3480edc41d12610d790ec52fb17f6b44e81af2de4d2ff9",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "266ee7699ab76f16f350c3cf900e7aa3ba1f56643a09742c44b205ea4dccb765",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "0014973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qjuagpj2x4zhcafwnhx65jzxdvzaktjkgrhny92",
+						"value": 1000000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"304402207d7e92fd3f877321ffd784f14a9ec047849ab005bddcfa415b0f1c2a60738dbb02205a9a944acc91cd74383ff6c5d8aebc675924119b4123c832092bb48694f5e65301",
+						"0257aeef9bfc8cfebe61cc24285963a171845e119f91ebb502d8890be5088cc74f"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "00143c9f62977ef7db087cfd9eec97a2cfff5647e02d",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 3c9f62977ef7db087cfd9eec97a2cfff5647e02d",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1q8j0k99m77ldssl8anmkf0gk0laty0cpdv65ss3",
+					"value": 200000
+				},
+				{
+					"scriptpubkey": "00146ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 6ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r",
+					"value": 797288
+				}
+			],
+			"size": 222,
+			"weight": 561,
+			"fee": 2712,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835794,
+				"block_hash": "000000000000004cbee74141246d4a6d340c57aac75cdf352d95f30fed852100",
+				"block_time": 1600924626
+			}
+		},
+		{
+			"txid": "266ee7699ab76f16f350c3cf900e7aa3ba1f56643a09742c44b205ea4dccb765",
+			"version": 2,
+			"locktime": 1835702,
+			"vin": [
+				{
+					"txid": "537c7e9935629b160fb64d4bd3d0ba884e264a0018fcb789c76798bf9a9b8b18",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "a914205a31d0e75793beff92c0a93647ec3153e3b9da87",
+						"scriptpubkey_asm": "OP_HASH160 OP_PUSHBYTES_20 205a31d0e75793beff92c0a93647ec3153e3b9da OP_EQUAL",
+						"scriptpubkey_type": "p2sh",
+						"scriptpubkey_address": "2MvCHfFcacfxpqceib74d67znVaLG6vVqC5",
+						"value": 2798720
+					},
+					"scriptsig": "16001462bebcf191587bc2f14362d22e2605cf3ffa69bd",
+					"scriptsig_asm": "OP_PUSHBYTES_22 001462bebcf191587bc2f14362d22e2605cf3ffa69bd",
+					"witness": [
+						"3044022060132b2c3a76c92eafec590fa12b16db3ef5db3b28f977465987b8f7a8dd44c5022066b39cf847fc59ba6ea888a8c4f3341e07e253659d56a2110e9efc006d5c670801",
+						"0263cf724bc0042c557bf502df103bd4d4497b88b79cbfa0293bf44470f98e7c39"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967294,
+					"inner_redeemscript_asm": "OP_0 OP_PUSHBYTES_20 62bebcf191587bc2f14362d22e2605cf3ffa69bd"
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "0014973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qjuagpj2x4zhcafwnhx65jzxdvzaktjkgrhny92",
+					"value": 1000000
+				},
+				{
+					"scriptpubkey": "0014bdf75a361126c3c35090b29d2172333f63ffcfeb",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 bdf75a361126c3c35090b29d2172333f63ffcfeb",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qhhm45ds3ympux5ysk2wjzu3n8a3llnlt6rysh3",
+					"value": 1798556
+				}
+			],
+			"size": 245,
+			"weight": 653,
+			"fee": 164,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835793,
+				"block_hash": "000000000000004243f1349332d34d3109bdb62182ada1603884c32788336747",
+				"block_time": 1600923695
+			}
+		},
+		{
+			"txid": "ecfb6a6c096089a888b88fc0c0133626ef178cae4750fd8ca36a90184135a45d",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "5b00f5bd218d09071d3480edc41d12610d790ec52fb17f6b44e81af2de4d2ff9",
+					"vout": 1,
+					"prevout": {
+						"scriptpubkey": "00146ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 6ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r",
+						"value": 797288
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"3045022100b7344203963d6de5ced838bc71893fff7dbf5aed0f1334f705a97e293ab576d30220668e46dc1120fdf783dd4e884906aef802b464af020ccfc3b4c2f7d974fe248c01",
+						"03f676a46e2930141b3c49acef931fdf8228ebea14aafca3f9f7e382b4a34d5710"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "0014410d578d23e0fa636b337b7687bae1ef14473720",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 410d578d23e0fa636b337b7687bae1ef14473720",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n",
+					"value": 500000
+				},
+				{
+					"scriptpubkey": "0014da48e5802830ae77a22edde7fdfe37ac367ba6a6",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 da48e5802830ae77a22edde7fdfe37ac367ba6a6",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qmfywtqpgxzh80g3wmhnlml3h4sm8hf4xypqq2q",
+					"value": 294802
+				}
+			],
+			"size": 223,
+			"weight": 562,
+			"fee": 2486,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835795,
+				"block_hash": "00000000fbe5656327501bc53ca701d6626fcc5ee034b1a9a8a0b9a018b0b007",
+				"block_time": 1600925827
+			}
+		},
+		{
+			"txid": "5b00f5bd218d09071d3480edc41d12610d790ec52fb17f6b44e81af2de4d2ff9",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "266ee7699ab76f16f350c3cf900e7aa3ba1f56643a09742c44b205ea4dccb765",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "0014973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qjuagpj2x4zhcafwnhx65jzxdvzaktjkgrhny92",
+						"value": 1000000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"304402207d7e92fd3f877321ffd784f14a9ec047849ab005bddcfa415b0f1c2a60738dbb02205a9a944acc91cd74383ff6c5d8aebc675924119b4123c832092bb48694f5e65301",
+						"0257aeef9bfc8cfebe61cc24285963a171845e119f91ebb502d8890be5088cc74f"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "00143c9f62977ef7db087cfd9eec97a2cfff5647e02d",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 3c9f62977ef7db087cfd9eec97a2cfff5647e02d",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1q8j0k99m77ldssl8anmkf0gk0laty0cpdv65ss3",
+					"value": 200000
+				},
+				{
+					"scriptpubkey": "00146ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 6ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r",
+					"value": 797288
+				}
+			],
+			"size": 222,
+			"weight": 561,
+			"fee": 2712,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835794,
+				"block_hash": "000000000000004cbee74141246d4a6d340c57aac75cdf352d95f30fed852100",
+				"block_time": 1600924626
+			}
+		},
+		{
+			"txid": "5b00f5bd218d09071d3480edc41d12610d790ec52fb17f6b44e81af2de4d2ff9",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "266ee7699ab76f16f350c3cf900e7aa3ba1f56643a09742c44b205ea4dccb765",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "0014973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 973a80c946a8af8ea5d3b9b54908cd60bb65cac8",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qjuagpj2x4zhcafwnhx65jzxdvzaktjkgrhny92",
+						"value": 1000000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"304402207d7e92fd3f877321ffd784f14a9ec047849ab005bddcfa415b0f1c2a60738dbb02205a9a944acc91cd74383ff6c5d8aebc675924119b4123c832092bb48694f5e65301",
+						"0257aeef9bfc8cfebe61cc24285963a171845e119f91ebb502d8890be5088cc74f"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "00143c9f62977ef7db087cfd9eec97a2cfff5647e02d",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 3c9f62977ef7db087cfd9eec97a2cfff5647e02d",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1q8j0k99m77ldssl8anmkf0gk0laty0cpdv65ss3",
+					"value": 200000
+				},
+				{
+					"scriptpubkey": "00146ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 6ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r",
+					"value": 797288
+				}
+			],
+			"size": 222,
+			"weight": 561,
+			"fee": 2712,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835794,
+				"block_hash": "000000000000004cbee74141246d4a6d340c57aac75cdf352d95f30fed852100",
+				"block_time": 1600924626
+			}
+		},
+		{
+			"txid": "ecfb6a6c096089a888b88fc0c0133626ef178cae4750fd8ca36a90184135a45d",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "5b00f5bd218d09071d3480edc41d12610d790ec52fb17f6b44e81af2de4d2ff9",
+					"vout": 1,
+					"prevout": {
+						"scriptpubkey": "00146ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 6ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r",
+						"value": 797288
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"3045022100b7344203963d6de5ced838bc71893fff7dbf5aed0f1334f705a97e293ab576d30220668e46dc1120fdf783dd4e884906aef802b464af020ccfc3b4c2f7d974fe248c01",
+						"03f676a46e2930141b3c49acef931fdf8228ebea14aafca3f9f7e382b4a34d5710"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "0014410d578d23e0fa636b337b7687bae1ef14473720",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 410d578d23e0fa636b337b7687bae1ef14473720",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n",
+					"value": 500000
+				},
+				{
+					"scriptpubkey": "0014da48e5802830ae77a22edde7fdfe37ac367ba6a6",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 da48e5802830ae77a22edde7fdfe37ac367ba6a6",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qmfywtqpgxzh80g3wmhnlml3h4sm8hf4xypqq2q",
+					"value": 294802
+				}
+			],
+			"size": 223,
+			"weight": 562,
+			"fee": 2486,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835795,
+				"block_hash": "00000000fbe5656327501bc53ca701d6626fcc5ee034b1a9a8a0b9a018b0b007",
+				"block_time": 1600925827
+			}
+		},
+		{
+			"txid": "5c40d01bd00a7a44e5dd69411f6709365fabd6e42562860af8e14873d86e81de",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "ecfb6a6c096089a888b88fc0c0133626ef178cae4750fd8ca36a90184135a45d",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "0014410d578d23e0fa636b337b7687bae1ef14473720",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 410d578d23e0fa636b337b7687bae1ef14473720",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n",
+						"value": 500000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"304402207d142fbe8f48fbc2d7ca295fae7ec453d77debba3c7a572f2c584f6f525862890220224a4e98ea388b8a293eb3185ac67ac74811108c8895c1ba798c249f849b8b0601",
+						"03480ab150e23e56a7567e0b2bdc70a6c7e545d13f37e980fa200481a01b72ec15"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "001480c2b5915b93d212d094beea6ab7d7e352b68f3a",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 80c2b5915b93d212d094beea6ab7d7e352b68f3a",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qsrptty2mj0fp95y5hm4x4d7hudftdre62cmhqq",
+					"value": 300000
+				},
+				{
+					"scriptpubkey": "0014ed302660b67f364e1b74141dd5f97c0255822f09",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 ed302660b67f364e1b74141dd5f97c0255822f09",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qa5czvc9k0umyuxm5zswat7tuqf2cytcfs4uery",
+					"value": 195028
+				}
+			],
+			"size": 222,
+			"weight": 561,
+			"fee": 4972,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835871,
+				"block_hash": "000000000000001499ca86743a31be72e08d35b738e8cb8d10ed9c6d80cd0a6e",
+				"block_time": 1600969709
+			}
+		},
+		{
+			"txid": "ecfb6a6c096089a888b88fc0c0133626ef178cae4750fd8ca36a90184135a45d",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "5b00f5bd218d09071d3480edc41d12610d790ec52fb17f6b44e81af2de4d2ff9",
+					"vout": 1,
+					"prevout": {
+						"scriptpubkey": "00146ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 6ae1d8cbb872b0d7dede89174eef651f07cbb8b6",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r",
+						"value": 797288
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"3045022100b7344203963d6de5ced838bc71893fff7dbf5aed0f1334f705a97e293ab576d30220668e46dc1120fdf783dd4e884906aef802b464af020ccfc3b4c2f7d974fe248c01",
+						"03f676a46e2930141b3c49acef931fdf8228ebea14aafca3f9f7e382b4a34d5710"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "0014410d578d23e0fa636b337b7687bae1ef14473720",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 410d578d23e0fa636b337b7687bae1ef14473720",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n",
+					"value": 500000
+				},
+				{
+					"scriptpubkey": "0014da48e5802830ae77a22edde7fdfe37ac367ba6a6",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 da48e5802830ae77a22edde7fdfe37ac367ba6a6",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qmfywtqpgxzh80g3wmhnlml3h4sm8hf4xypqq2q",
+					"value": 294802
+				}
+			],
+			"size": 223,
+			"weight": 562,
+			"fee": 2486,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835795,
+				"block_hash": "00000000fbe5656327501bc53ca701d6626fcc5ee034b1a9a8a0b9a018b0b007",
+				"block_time": 1600925827
+			}
+		},
+		{
+			"txid": "5c40d01bd00a7a44e5dd69411f6709365fabd6e42562860af8e14873d86e81de",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "ecfb6a6c096089a888b88fc0c0133626ef178cae4750fd8ca36a90184135a45d",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "0014410d578d23e0fa636b337b7687bae1ef14473720",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 410d578d23e0fa636b337b7687bae1ef14473720",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n",
+						"value": 500000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"304402207d142fbe8f48fbc2d7ca295fae7ec453d77debba3c7a572f2c584f6f525862890220224a4e98ea388b8a293eb3185ac67ac74811108c8895c1ba798c249f849b8b0601",
+						"03480ab150e23e56a7567e0b2bdc70a6c7e545d13f37e980fa200481a01b72ec15"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "001480c2b5915b93d212d094beea6ab7d7e352b68f3a",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 80c2b5915b93d212d094beea6ab7d7e352b68f3a",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qsrptty2mj0fp95y5hm4x4d7hudftdre62cmhqq",
+					"value": 300000
+				},
+				{
+					"scriptpubkey": "0014ed302660b67f364e1b74141dd5f97c0255822f09",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 ed302660b67f364e1b74141dd5f97c0255822f09",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qa5czvc9k0umyuxm5zswat7tuqf2cytcfs4uery",
+					"value": 195028
+				}
+			],
+			"size": 222,
+			"weight": 561,
+			"fee": 4972,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835871,
+				"block_hash": "000000000000001499ca86743a31be72e08d35b738e8cb8d10ed9c6d80cd0a6e",
+				"block_time": 1600969709
+			}
+		},
+		{
+			"txid": "4282b9c93e5b9676db8d87897495b33ccbf6f9e07d5ce80a0c82a144afa559ff",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "5c40d01bd00a7a44e5dd69411f6709365fabd6e42562860af8e14873d86e81de",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "001480c2b5915b93d212d094beea6ab7d7e352b68f3a",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 80c2b5915b93d212d094beea6ab7d7e352b68f3a",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qsrptty2mj0fp95y5hm4x4d7hudftdre62cmhqq",
+						"value": 300000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"3045022100f99d403d5777a312fb1124ca761f55aba29a43105125d83b9d48e62c195b90120220599ae7b0c6e4aa2c2c912929675a2b27a9306d2aaba5953e078f386a83e70fcd01",
+						"0227dd270531638f399db88690093a73af38e3a32fa52cdc7230c331dd9f12ed1f"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "0014fdcf5c3e958f24e6843b7d1f858b691932fa4818",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 fdcf5c3e958f24e6843b7d1f858b691932fa4818",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qlh84c0543ujwdppm050ctzmfrye05jqc9yq39l",
+					"value": 100000
+				},
+				{
+					"scriptpubkey": "00143f98f11e19b493d1dc7249646b99b0669e413f31",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 3f98f11e19b493d1dc7249646b99b0669e413f31",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1q87v0z8sekjfarhrjf9jxhxdsv60yz0e3yw89t9",
+					"value": 197514
+				}
+			],
+			"size": 223,
+			"weight": 562,
+			"fee": 2486,
+			"status": {
+				"confirmed": true,
+				"block_height": 1837831,
+				"block_hash": "00000000000000843b51c5ae278bef4df0b230404657c1a8df933c1d9d6923f0",
+				"block_time": 1601837134
+			}
+		},
+		{
+			"txid": "5c40d01bd00a7a44e5dd69411f6709365fabd6e42562860af8e14873d86e81de",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "ecfb6a6c096089a888b88fc0c0133626ef178cae4750fd8ca36a90184135a45d",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "0014410d578d23e0fa636b337b7687bae1ef14473720",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 410d578d23e0fa636b337b7687bae1ef14473720",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n",
+						"value": 500000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"304402207d142fbe8f48fbc2d7ca295fae7ec453d77debba3c7a572f2c584f6f525862890220224a4e98ea388b8a293eb3185ac67ac74811108c8895c1ba798c249f849b8b0601",
+						"03480ab150e23e56a7567e0b2bdc70a6c7e545d13f37e980fa200481a01b72ec15"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "001480c2b5915b93d212d094beea6ab7d7e352b68f3a",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 80c2b5915b93d212d094beea6ab7d7e352b68f3a",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qsrptty2mj0fp95y5hm4x4d7hudftdre62cmhqq",
+					"value": 300000
+				},
+				{
+					"scriptpubkey": "0014ed302660b67f364e1b74141dd5f97c0255822f09",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 ed302660b67f364e1b74141dd5f97c0255822f09",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qa5czvc9k0umyuxm5zswat7tuqf2cytcfs4uery",
+					"value": 195028
+				}
+			],
+			"size": 222,
+			"weight": 561,
+			"fee": 4972,
+			"status": {
+				"confirmed": true,
+				"block_height": 1835871,
+				"block_hash": "000000000000001499ca86743a31be72e08d35b738e8cb8d10ed9c6d80cd0a6e",
+				"block_time": 1600969709
+			}
+		},
+		{
+			"txid": "4282b9c93e5b9676db8d87897495b33ccbf6f9e07d5ce80a0c82a144afa559ff",
+			"version": 2,
+			"locktime": 0,
+			"vin": [
+				{
+					"txid": "5c40d01bd00a7a44e5dd69411f6709365fabd6e42562860af8e14873d86e81de",
+					"vout": 0,
+					"prevout": {
+						"scriptpubkey": "001480c2b5915b93d212d094beea6ab7d7e352b68f3a",
+						"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 80c2b5915b93d212d094beea6ab7d7e352b68f3a",
+						"scriptpubkey_type": "v0_p2wpkh",
+						"scriptpubkey_address": "tb1qsrptty2mj0fp95y5hm4x4d7hudftdre62cmhqq",
+						"value": 300000
+					},
+					"scriptsig": "",
+					"scriptsig_asm": "",
+					"witness": [
+						"3045022100f99d403d5777a312fb1124ca761f55aba29a43105125d83b9d48e62c195b90120220599ae7b0c6e4aa2c2c912929675a2b27a9306d2aaba5953e078f386a83e70fcd01",
+						"0227dd270531638f399db88690093a73af38e3a32fa52cdc7230c331dd9f12ed1f"
+					],
+					"is_coinbase": false,
+					"sequence": 4294967295
+				}
+			],
+			"vout": [
+				{
+					"scriptpubkey": "0014fdcf5c3e958f24e6843b7d1f858b691932fa4818",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 fdcf5c3e958f24e6843b7d1f858b691932fa4818",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1qlh84c0543ujwdppm050ctzmfrye05jqc9yq39l",
+					"value": 100000
+				},
+				{
+					"scriptpubkey": "00143f98f11e19b493d1dc7249646b99b0669e413f31",
+					"scriptpubkey_asm": "OP_0 OP_PUSHBYTES_20 3f98f11e19b493d1dc7249646b99b0669e413f31",
+					"scriptpubkey_type": "v0_p2wpkh",
+					"scriptpubkey_address": "tb1q87v0z8sekjfarhrjf9jxhxdsv60yz0e3yw89t9",
+					"value": 197514
+				}
+			],
+			"size": 223,
+			"weight": 562,
+			"fee": 2486,
+			"status": {
+				"confirmed": true,
+				"block_height": 1837831,
+				"block_hash": "00000000000000843b51c5ae278bef4df0b230404657c1a8df933c1d9d6923f0",
+				"block_time": 1601837134
+			}
+		}
+	],
+	"addresses": {
+		"external": [
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qjuagpj2x4zhcafwnhx65jzxdvzaktjkgrhny92"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q8j0k99m77ldssl8anmkf0gk0laty0cpdv65ss3"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qgyx40rfruraxx6en0dmg0whpau2ywdeqtrfd9n"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qsrptty2mj0fp95y5hm4x4d7hudftdre62cmhqq"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qjk8n74sfx928f2sdgs98szzh9mm4xvdjhw7wkk"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q0lfzwghsaal4qghwcaelnfemfamtt0fz0c39yc"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qz2fl6j4axzwul2nfd0cfchst4h7662xwsnv8ns"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qcrlgetr49k2dz4qx60hq8t9de3mfnglagkkxm0"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q2j8mlyfl8hvxvahxnd6n75sg4w68uchzdvmeet"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qxurc6am8v5fud4ltq8taka2q6zwc7s5d2fh7sm"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qqcfktdtwlffdyc92z8mx9zl8qmgc6svcju6k3a"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q9g79nj79a4uq75h0p9w65w7kurj9yhyuzwld8t"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qzastuyh0rlfxn6lknvq4j8z9pc5vge58m2p6x8"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q4rs083qvsyflmycee8y5lsqttvwqgpp2pldxej"
+			}
+		],
+		"change": [
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qdtsa3jacw2cd0hk73yt5amm9ruruhw9kqzc26r"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qmfywtqpgxzh80g3wmhnlml3h4sm8hf4xypqq2q"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qa5czvc9k0umyuxm5zswat7tuqf2cytcfs4uery"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q87v0z8sekjfarhrjf9jxhxdsv60yz0e3yw89t9"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qqm2jspk4t3gucel7r7uu09m46hdst2gmdpkzpj"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qcrzceyj93kr0zfwjlwtzaa3ap6mkxqe55z4rmy"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qjjfc6keg3ur0kvlz22yz2cty66awmzjnme4ppr"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1q8ef2hz7q7nrxdla7epsxrj0v6t0d9rdq3p7jj9"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qxquwt2gaafg5xz0y3xz47fxmzhscmxtv0s9x46"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qvpxl3gyl8p24xe0xga97hhyujzmdahp6ncf2v6"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qzmdpdnt57fan3haldw3v4r2wheu4p6083jcfuw"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qd0895s7xz5h9xx8043pfpvd2xjgptqyhumj62q"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qt0dv8xfelt5md6e0lksf968smz30x4lv443kvj"
+			},
+			{
+				"name": "p2wpkh",
+				"network": {
+					"messagePrefix": "\u0018Bitcoin Signed Message:\n",
+					"bech32": "tb",
+					"pubKeyHash": 111,
+					"scriptHash": 196,
+					"wif": 239
+				},
+				"address": "tb1qhxknwtkvezpm9cav6d6ml7z3qhxm9kwun8jw0m"
+			}
+		]
+	}		
+}

--- a/test/utils/transactions.test.js
+++ b/test/utils/transactions.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const {
+	original,
+	addresses } = require('../fixtures/serializeTransactions.json');
+const { external, change } = addresses;
+
+const rewire = require('rewire');
+const transactions = rewire('../../src/utils/transactions.js');
+
+const serializeTransactions = transactions.__get__('serializeTransactions');
+
+describe('transactions', function() {
+	describe('#serializeTransactions', function() {
+		const txs = serializeTransactions(original, external, change);
+		// Testing expected tx 'type' attributes
+		assert.strictEqual(txs[4].type, 'received');
+		assert.strictEqual(txs[3].type, 'moved');
+		assert.strictEqual(txs[2].type, 'moved');
+		assert.strictEqual(txs[1].type, 'moved');
+		assert.strictEqual(txs[0].type, 'sent');
+		// Testing expected balance
+		assert.strictEqual(txs[4].totalValue, 1000000);
+		assert.strictEqual(txs[3].totalValue, 997288);
+		assert.strictEqual(txs[2].totalValue, 994802);
+		assert.strictEqual(txs[1].totalValue, 989830);
+		assert.strictEqual(txs[0].totalValue, 884858);
+	});
+});


### PR DESCRIPTION
This fixes the wallet balance graph. See [here](https://imgur.com/a/FOlX1mn) the previous version and [here](https://imgur.com/91xfwVC) for the fixed one. This is a wallet that has received 0.010 BTC and performed 3 self-transfers before the final outward transfer.

With this we now have 3 types of transactions: 

1- received
2- sent
3- moved

The color scheme was then extended and the existing gray was designated to `moved` (self-transfers) transactions due to it's apparent neutrality. A light red tone was chosen for outgoing transactions as the opposite of the green which was traditionally assigned to incoming txs. [Here](https://imgur.com/yZaQgcv)'s a screenshot of how the modified tx list looks like.

Also a small automated test was introduced. This uses mocha and can be later on expanded to include more unit tests.

