### PR TITLE
refactor, get currentAccount and setCurrentAccountId from context

### DIFF
--- a/src/AccountMapContext.js
+++ b/src/AccountMapContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useReducer, useCallback } from 'react';
+import React, { createContext, useReducer, useCallback, useState } from 'react';
 
 import {
   accountMapReducer,
@@ -9,7 +9,10 @@ import {
 export const AccountMapContext = createContext();
 
 export const AccountMapProvider = ({ children }) => {
-  const [accountMap, dispatch] = useReducer(accountMapReducer, {})
+  const [accountMap, dispatch] = useReducer(accountMapReducer, {});
+  const [currentAccountId, setCurrentAccountId] = useState(undefined);
+
+  const currentAccount = accountMap[currentAccountId] || { name: 'Loading...', loading: true, transactions: [], unusedAddresses: [], currentBalance: 0, config: {} };
 
   const updateAccountMap = useCallback(account => {
     dispatch({
@@ -27,9 +30,7 @@ export const AccountMapProvider = ({ children }) => {
     })
   }, [dispatch])
 
-  const value = { accountMap, updateAccountMap, setAccountMap }
-
-  console.log('AccountMapProvider renders',);
+  const value = { accountMap, updateAccountMap, setAccountMap, currentAccount, setCurrentAccountId }
 
   return <AccountMapContext.Provider value={value}>{children}</AccountMapContext.Provider>
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useReducer, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useContext, memo } from 'react';
 import styled, { css } from 'styled-components';
 import {
   HashRouter as Router,
@@ -14,8 +14,6 @@ import { networks } from 'bitcoinjs-lib';
 import { offWhite } from './utils/colors';
 import { mobile } from './utils/media';
 
-import { ACCOUNTMAP_UPDATE, ACCOUNTMAP_SET, accountMapReducer } from './reducers/accountMap';
-
 import { Sidebar, MobileNavbar, TitleBar, ScrollToTop } from './components';
 
 // Pages
@@ -30,6 +28,8 @@ import Home from './pages/Home';
 
 import { bitcoinNetworkEqual } from './utils/files';
 
+import { AccountMapContext } from './AccountMapContext';
+
 const emptyConfig = {
   name: "",
   version: "0.0.2",
@@ -43,23 +43,20 @@ const emptyConfig = {
   exchanges: []
 }
 
-function App() {
+const App = () => {
   const [currentBitcoinPrice, setCurrentBitcoinPrice] = useState(BigNumber(0));
   const [historicalBitcoinPrice, setHistoricalBitcoinPrice] = useState({});
   const [config, setConfigFile] = useState(emptyConfig);
   const [encryptedConfigFile, setEncryptedConfigFile] = useState(null);
   const [currentAccount, setCurrentAccount] = useState({ name: 'Loading...', loading: true, transactions: [], unusedAddresses: [], currentBalance: 0, config: {} });
-  // const [accountMap, setAccountMap] = useState({});
-  const [accountMap, dispatch] = useReducer(accountMapReducer, {})
-
-
-
   const [currentBitcoinNetwork, setCurrentBitcoinNetwork] = useState(networks.bitcoin);
   const [refresh, setRefresh] = useState(false);
   const [flyInAnimation, setInitialFlyInAnimation] = useState(true);
   const [nodeConfig, setNodeConfig] = useState(undefined);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [password, setPassword] = useState('');
+
+  const { accountMap, setAccountMap, updateAccountMap } = useContext(AccountMapContext);
 
   const ConfigRequired = () => {
     const { pathname } = useLocation();
@@ -79,13 +76,6 @@ function App() {
     const { file, modifiedTime } = await window.ipcRenderer.invoke('/get-config');
     setEncryptedConfigFile({ file: file.toString(), modifiedTime });
     setInitialFlyInAnimation(true);
-  }
-
-  const setCurrentAccountFromMap = (accountId) => {
-    const newAccount = accountMap[accountId];
-    if (newAccount) {
-      setCurrentAccount(newAccount);
-    }
   }
 
   const changeCurrentBitcoinNetwork = () => {
@@ -196,23 +186,6 @@ function App() {
     fetchNodeConfig();
   }, []);
 
-
-  const updateAccountMap = useCallback(account => {
-    dispatch({
-      type: ACCOUNTMAP_UPDATE,
-      payload: {
-        account
-      }
-    })
-  }, [dispatch])
-
-  const setAccountMap = useCallback(accountMap => {
-    dispatch({
-      type: ACCOUNTMAP_SET,
-      payload: accountMap
-    })
-  }, [dispatch])
-
   // fetch/build account data from config file
   useEffect(() => {
     if (config.wallets.length || config.vaults.length) {
@@ -247,13 +220,9 @@ function App() {
         })
       });
 
-      console.log('initialAccountMap: ', initialAccountMap);
-
       setAccountMap(initialAccountMap)
     }
   }, [config, refresh, nodeConfig]);
-
-  console.log('app renders')
 
   return (
     <Router>
@@ -261,18 +230,18 @@ function App() {
       <TitleBar setNodeConfig={setNodeConfig} nodeConfig={nodeConfig} setMobileNavOpen={setMobileNavOpen} config={config} connectToBlockstream={connectToBlockstream} connectToBitcoinCore={connectToBitcoinCore} connectToCustomNode={connectToCustomNode} getNodeConfig={getNodeConfig} resetConfigFile={resetConfigFile} />
       <PageWrapper id="page-wrapper">
         <ConfigRequired />
-        {!config.isEmpty && <Sidebar config={config} setCurrentAccount={setCurrentAccountFromMap} flyInAnimation={flyInAnimation} currentBitcoinNetwork={currentBitcoinNetwork} />}
-        {!config.isEmpty && <MobileNavbar mobileNavOpen={mobileNavOpen} setMobileNavOpen={setMobileNavOpen} config={config} setCurrentAccount={setCurrentAccountFromMap} currentBitcoinNetwork={currentBitcoinNetwork} />}
+        {!config.isEmpty && <Sidebar config={config} flyInAnimation={flyInAnimation} currentBitcoinNetwork={currentBitcoinNetwork} />}
+        {!config.isEmpty && <MobileNavbar mobileNavOpen={mobileNavOpen} setMobileNavOpen={setMobileNavOpen} config={config} currentBitcoinNetwork={currentBitcoinNetwork} />}
         <Switch>
-          <Route path="/vault/:id" component={() => <Vault config={config} setConfigFile={setConfigFile} password={password} toggleRefresh={toggleRefresh} currentAccount={currentAccount} setCurrentAccount={setCurrentAccountFromMap} currentBitcoinNetwork={currentBitcoinNetwork} currentBitcoinPrice={currentBitcoinPrice} />} />
-          <Route path="/receive" component={() => <Receive config={config} currentAccount={currentAccount} setCurrentAccount={setCurrentAccountFromMap} currentBitcoinPrice={currentBitcoinPrice} />} />
-          <Route path="/send" component={() => <Send config={config} currentAccount={currentAccount} setCurrentAccount={setCurrentAccountFromMap} toggleRefresh={toggleRefresh} currentBitcoinPrice={currentBitcoinPrice} currentBitcoinNetwork={currentBitcoinNetwork} />} />
-          <Route path="/setup" component={() => <Setup config={config} setConfigFile={setConfigFile} password={password} encryptedConfigFile={encryptedConfigFile} setEncryptedConfigFile={setEncryptedConfigFile} currentBitcoinNetwork={currentBitcoinNetwork} />} />
-          <Route path="/login" component={() => <Login config={config} setConfigFile={setConfigFile} setPassword={setPassword} encryptedConfigFile={encryptedConfigFile} setEncryptedConfigFile={setEncryptedConfigFile} currentBitcoinNetwork={currentBitcoinNetwork} />} />
-          <Route path="/settings" component={() => <Settings config={config} currentBitcoinNetwork={currentBitcoinNetwork} changeCurrentBitcoinNetwork={changeCurrentBitcoinNetwork} />} />
-          <Route path="/coldcard-import-instructions" component={() => <ColdcardImportInstructions />} />
-          <Route path="/" component={() => <Home flyInAnimation={flyInAnimation} prevFlyInAnimation={prevSetFlyInAnimation.current} accountMap={accountMap} setCurrentAccount={setCurrentAccountFromMap} historicalBitcoinPrice={historicalBitcoinPrice} currentBitcoinPrice={currentBitcoinPrice} />} />
-          <Route path="/" component={() => (
+          <Route path="/vault/:id" render={() => <Vault config={config} setConfigFile={setConfigFile} password={password} toggleRefresh={toggleRefresh} currentBitcoinNetwork={currentBitcoinNetwork} />} />
+          <Route path="/receive" render={() => <Receive config={config} />} />
+          <Route path="/send" render={() => <Send config={config} currentBitcoinPrice={currentBitcoinPrice} currentBitcoinNetwork={currentBitcoinNetwork} />} />
+          <Route path="/setup" render={() => <Setup config={config} setConfigFile={setConfigFile} password={password} encryptedConfigFile={encryptedConfigFile} setEncryptedConfigFile={setEncryptedConfigFile} currentBitcoinNetwork={currentBitcoinNetwork} />} />
+          <Route path="/login" render={() => <Login config={config} setConfigFile={setConfigFile} setPassword={setPassword} encryptedConfigFile={encryptedConfigFile} setEncryptedConfigFile={setEncryptedConfigFile} currentBitcoinNetwork={currentBitcoinNetwork} />} />
+          <Route path="/settings" render={() => <Settings config={config} currentBitcoinNetwork={currentBitcoinNetwork} changeCurrentBitcoinNetwork={changeCurrentBitcoinNetwork} />} />
+          <Route path="/coldcard-import-instructions" render={() => <ColdcardImportInstructions />} />
+          <Route path="/" render={() => <Home flyInAnimation={flyInAnimation} prevFlyInAnimation={prevSetFlyInAnimation.current} historicalBitcoinPrice={historicalBitcoinPrice} currentBitcoinPrice={currentBitcoinPrice} />} />
+          <Route path="/" render={() => (
             <div>Not Found</div>
           )}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useContext, memo } from 'react';
+import React, { useEffect, useState, useRef, useContext } from 'react';
 import styled, { css } from 'styled-components';
 import {
   HashRouter as Router,
@@ -48,7 +48,6 @@ const App = () => {
   const [historicalBitcoinPrice, setHistoricalBitcoinPrice] = useState({});
   const [config, setConfigFile] = useState(emptyConfig);
   const [encryptedConfigFile, setEncryptedConfigFile] = useState(null);
-  const [currentAccount, setCurrentAccount] = useState({ name: 'Loading...', loading: true, transactions: [], unusedAddresses: [], currentBalance: 0, config: {} });
   const [currentBitcoinNetwork, setCurrentBitcoinNetwork] = useState(networks.bitcoin);
   const [refresh, setRefresh] = useState(false);
   const [flyInAnimation, setInitialFlyInAnimation] = useState(true);
@@ -56,7 +55,7 @@ const App = () => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [password, setPassword] = useState('');
 
-  const { accountMap, setAccountMap, updateAccountMap } = useContext(AccountMapContext);
+  const { setAccountMap, updateAccountMap } = useContext(AccountMapContext);
 
   const ConfigRequired = () => {
     const { pathname } = useLocation();

--- a/src/components/MobileNavbar.js
+++ b/src/components/MobileNavbar.js
@@ -7,7 +7,7 @@ import { NavLinks, Transition, Button, StyledIcon } from '.';
 import { white, gray800 } from '../utils/colors';
 import { mobile } from '../utils/media';
 
-export const MobileNavbar = ({ config, setCurrentAccount, mobileNavOpen, setMobileNavOpen, currentBitcoinNetwork }) => (
+export const MobileNavbar = ({ config, mobileNavOpen, setMobileNavOpen, currentBitcoinNetwork }) => (
   <Wrapper>
     <Transition
       show={mobileNavOpen}
@@ -34,7 +34,7 @@ export const MobileNavbar = ({ config, setCurrentAccount, mobileNavOpen, setMobi
     >
       <SomeContainer>
         <SidebarContainer>
-          <NavLinks config={config} setCurrentAccount={setCurrentAccount} setMobileNavOpen={setMobileNavOpen} currentBitcoinNetwork={currentBitcoinNetwork} />
+          <NavLinks config={config} setMobileNavOpen={setMobileNavOpen} currentBitcoinNetwork={currentBitcoinNetwork} />
           <CloseButtonContainer>
             <CloseButton background="transparent" onClick={() => setMobileNavOpen(false)}>
               <StyledIcon as={CloseOutline} size={36} />

--- a/src/components/NavLinks.js
+++ b/src/components/NavLinks.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useContext } from 'react';
 import styled, { css } from 'styled-components';
 import { Link, useLocation } from "react-router-dom";
 import { VerticalAlignBottom, AddCircleOutline, Settings } from '@styled-icons/material';
@@ -8,12 +8,15 @@ import { networks } from 'bitcoinjs-lib';
 
 import { StyledIcon } from '.';
 
+import { AccountMapContext } from '../AccountMapContext';
+
 import { white, offWhite, darkGray, darkOffWhite, lightBlack, green100, green700 } from '../utils/colors';
 import { bitcoinNetworkEqual } from '../utils/files';
 
 
-export const NavLinks = ({ config, setCurrentAccount, currentBitcoinNetwork }) => {
+export const NavLinks = ({ config, currentBitcoinNetwork }) => {
   const { pathname } = useLocation();
+  const { setCurrentAccountId } = useContext(AccountMapContext);
 
   return (
     <Fragment>
@@ -55,7 +58,7 @@ export const NavLinks = ({ config, setCurrentAccount, currentBitcoinNetwork }) =
               key={wallet.id}
               active={pathname === `/vault/${wallet.id}`}
               onClick={() => {
-                setCurrentAccount(wallet.id);
+                setCurrentAccountId(wallet.id);
               }}
               to={`/vault/${wallet.id}`}
             >
@@ -74,7 +77,7 @@ export const NavLinks = ({ config, setCurrentAccount, currentBitcoinNetwork }) =
               key={vault.id}
               active={pathname === `/vault/${vault.id}`}
               onClick={() => {
-                setCurrentAccount(vault.id);
+                setCurrentAccountId(vault.id);
               }}
               to={`/vault/${vault.id}`}
             >

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,7 +8,7 @@ import { NavLinks } from './NavLinks';
 import { white, darkOffWhite } from '../utils/colors';
 import { mobile } from '../utils/media';
 
-export const Sidebar = ({ config, setCurrentAccount, loading, flyInAnimation, currentBitcoinNetwork }) => {
+export const Sidebar = ({ config, loading, flyInAnimation, currentBitcoinNetwork }) => {
   const { pathname } = useLocation();
 
   const sidebarAnimationProps = useSpring({ transform: flyInAnimation ? 'translateX(-120%)' : 'translateX(0%)' });
@@ -21,7 +21,6 @@ export const Sidebar = ({ config, setCurrentAccount, loading, flyInAnimation, cu
           <SidebarContainer>
             <NavLinks
               config={config}
-              setCurrentAccount={setCurrentAccount}
               loading={loading}
               currentBitcoinNetwork={currentBitcoinNetwork}
             />

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,6 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+import { AccountMapProvider } from './AccountMapContext';
+
+ReactDOM.render(<AccountMapProvider><App /></AccountMapProvider>, document.getElementById('root'));

--- a/src/pages/Home/AccountsSection.js
+++ b/src/pages/Home/AccountsSection.js
@@ -1,0 +1,116 @@
+import React, { Fragment, useContext } from 'react';
+import styled from 'styled-components';
+import { Link } from "react-router-dom";
+import { Bitcoin } from '@styled-icons/boxicons-logos';
+import { AddCircleOutline } from '@styled-icons/material';
+import { satoshisToBitcoins } from "unchained-bitcoin";
+import moment from 'moment';
+
+import { AccountMapContext } from '../../AccountMapContext';
+
+import { StyledIcon } from '../../components';
+
+import { darkGray, white, gray500, black } from '../../utils/colors';
+
+const getLastTransactionTime = (transactions) => {
+  if (transactions.length === 0) { // if no transactions yet
+    return `No activity on this account yet`
+  } else if (!transactions[0].status.confirmed) { // if last transaction isn't confirmed yet
+    return `Last transaction was moments ago`
+  } else { // if transaction is confirmed, give moments ago
+    return `Last transaction was ${moment.unix(transactions[0].status.block_time).fromNow()}`
+  }
+}
+
+export const AccountsSection = () => {
+  const { accountMap, setCurrentAccountId } = useContext(AccountMapContext);
+
+  return (
+    <Fragment>
+      <HomeHeadingItem style={{ marginTop: '2.5em', marginBottom: '1em' }}>Your Accounts</HomeHeadingItem>
+      <AccountsWrapper>
+        {Object.values(accountMap).map((account) => (
+          <AccountItem
+            to={`/vault/${account.config.id}`}
+            onClick={() => setCurrentAccountId(account.config.id)}
+            key={account.config.id}>
+            <StyledIcon as={Bitcoin} size={48} />
+            <AccountInfoContainer>
+              <AccountName>{account.name}</AccountName>
+              {account.loading && 'Loading...'}
+              {!account.loading && <CurrentBalance>Current Balance: {satoshisToBitcoins(account.currentBalance).toFixed(8)} BTC</CurrentBalance>}
+              {!account.loading && <CurrentBalance>{getLastTransactionTime(account.transactions)}</CurrentBalance>}
+            </AccountInfoContainer>
+          </AccountItem>
+        ))}
+        <AccountItem to={`/setup`}>
+          <StyledIcon as={AddCircleOutline} size={48} />
+          <AccountInfoContainer>
+            <AccountName>Add a new account</AccountName>
+            <CurrentBalance>Create a new account to send, receive, and manage bitcoin</CurrentBalance>
+          </AccountInfoContainer>
+        </AccountItem>
+        {!accountMap.size && (
+          <InvisibleItem></InvisibleItem>
+        )}
+      </AccountsWrapper>
+    </Fragment>
+  )
+}
+
+const HomeHeadingItem = styled.h3`
+  font-size: 1.5em;
+  margin: 4em 0 0;
+  font-weight: 400;
+  color: ${black};
+`;
+
+const InvisibleItem = styled.div`
+  height: 0;
+  width: 0;
+`;
+
+const AccountItem = styled(Link)`
+  background: ${white};
+  padding: 1.5em;
+  cursor: pointer;
+  color: ${darkGray};
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  box-shadow: 0 1px 3px 0 rgba(0,0,0,.1), 0 1px 2px 0 rgba(0,0,0,.06);
+
+  &:hover {
+    color: ${gray500};
+  }
+
+  transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,transform;
+  transition-timing-function: cubic-bezier(.4,0,.2,1);
+  transition-duration: .15s;
+
+  &:active {
+    transform: scale(.99);
+    outline: 0;
+  }
+`;
+
+const AccountInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1em;
+`;
+
+const AccountsWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-gap: 1em;
+`;
+
+const AccountName = styled.div`
+  font-size: 1.25em;
+`;
+
+const CurrentBalance = styled.div`
+  font-size: 0.65em;
+`;

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -8,9 +8,11 @@ import { AreaChart, Area, ResponsiveContainer, XAxis, YAxis, Tooltip } from 'rec
 import { Link } from "react-router-dom";
 import { useSpring, animated } from 'react-spring';
 
-import { PageWrapper, StyledIcon } from '../components';
+import { PageWrapper, StyledIcon } from '../../components';
 
-import { green700, darkGray, white, black, lightgreen700, gray, gray500, yellow100, yellow500 } from '../utils/colors';
+import { AccountsSection } from './AccountsSection';
+
+import { green700, darkGray, white, black, lightgreen700, gray, gray500, yellow100, yellow500 } from '../../utils/colors';
 
 var formatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -40,7 +42,7 @@ const getLastTransactionTime = (transactions) => {
   }
 }
 
-const Home = ({ setCurrentAccount, accountMap, historicalBitcoinPrice, currentBitcoinPrice, flyInAnimation, prevFlyInAnimation }) => {
+const Home = ({ historicalBitcoinPrice, currentBitcoinPrice, flyInAnimation, prevFlyInAnimation }) => {
   const [currentDomain, setCurrentDomain] = useState(0);
   const [animateChart, setAnimateChart] = useState(false);
   const [initialLoad, setInitialLoad] = useState(false);
@@ -50,13 +52,6 @@ const Home = ({ setCurrentAccount, accountMap, historicalBitcoinPrice, currentBi
       setInitialLoad(true)
     }
   }, [flyInAnimation, prevFlyInAnimation]);
-
-  useEffect(() => {
-    console.log('component mounts');
-    return (
-      console.log('component unmounts')
-    )
-  }, [])
 
   const oneMonthDomain = Object.keys(historicalBitcoinPrice).length - 31;
   const sixMonthDomain = Object.keys(historicalBitcoinPrice).length - (30 * 6);
@@ -142,77 +137,11 @@ const Home = ({ setCurrentAccount, accountMap, historicalBitcoinPrice, currentBi
       </animated.div>
 
       <animated.div style={{ ...accountsProps }}>
-        <HomeHeadingItem style={{ marginTop: '2.5em', marginBottom: '1em' }}>Your Accounts</HomeHeadingItem>
-
-        <AccountsWrapper>
-          {Object.values(accountMap).map((account) => (
-            <AccountItem to={`/vault/${account.config.id}`} onClick={() => { setCurrentAccount(account.config.id) }} key={account.config.id}>
-              <StyledIcon as={Bitcoin} size={48} />
-              <AccountInfoContainer>
-                <AccountName>{account.name}</AccountName>
-                {account.loading && 'Loading...'}
-                {!account.loading && <CurrentBalance>Current Balance: {satoshisToBitcoins(account.currentBalance).toFixed(8)} BTC</CurrentBalance>}
-                {!account.loading && <CurrentBalance>{getLastTransactionTime(account.transactions)}</CurrentBalance>}
-              </AccountInfoContainer>
-            </AccountItem>
-          ))}
-          <AccountItem to={`/setup`}>
-            <StyledIcon as={AddCircleOutline} size={48} />
-            <AccountInfoContainer>
-              <AccountName>Add a new account</AccountName>
-              <CurrentBalance>Create a new account to send, receive, and manage bitcoin</CurrentBalance>
-            </AccountInfoContainer>
-          </AccountItem>
-          {!accountMap.size && (
-            <InvisibleItem></InvisibleItem>
-          )}
-        </AccountsWrapper>
+        <AccountsSection />
       </animated.div>
     </PageWrapper >
   )
 };
-
-const InvisibleItem = styled.div`
-  height: 0;
-  width: 0;
-`;
-
-const AccountItem = styled(Link)`
-  background: ${white};
-  padding: 1.5em;
-  cursor: pointer;
-  color: ${darkGray};
-  text-decoration: none;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  box-shadow: 0 1px 3px 0 rgba(0,0,0,.1), 0 1px 2px 0 rgba(0,0,0,.06);
-
-  &:hover {
-    color: ${gray500};
-  }
-
-  transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,transform;
-  transition-timing-function: cubic-bezier(.4,0,.2,1);
-  transition-duration: .15s;
-
-  &:active {
-    transform: scale(.99);
-    outline: 0;
-  }
-`;
-
-const AccountInfoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: 1em;
-`;
-
-const AccountsWrapper = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  grid-gap: 1em;
-`;
 
 const ChartInfo = styled.div`
   display: flex;
@@ -241,21 +170,6 @@ const CurrentBitcoinPriceContainer = styled.div`
   font-size: 2em;
   display: flex;
   flex-direction: column;
-`;
-
-const HomeHeadingItem = styled.h3`
-  font-size: 1.5em;
-  margin: 4em 0 0;
-  font-weight: 400;
-  color: ${black};
-`;
-
-const AccountName = styled.div`
-  font-size: 1.25em;
-`;
-
-const CurrentBalance = styled.div`
-  font-size: 0.65em;
 `;
 
 const ChartContainer = styled.div`

--- a/src/pages/Receive/index.js
+++ b/src/pages/Receive/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import styled, { css } from 'styled-components';
 import { Safe } from '@styled-icons/crypto';
 import { Wallet } from '@styled-icons/entypo';
@@ -9,13 +9,15 @@ import { satoshisToBitcoins } from "unchained-bitcoin";
 import { StyledIcon, Button, PageWrapper, GridArea, PageTitle, Header, HeaderRight, HeaderLeft, Loading } from '../../components';
 import RecentTransactions from '../../components/transactions/RecentTransactions';
 
+import { AccountMapContext } from '../../AccountMapContext';
+
 import { black, gray, darkGray, white, darkOffWhite, lightGray, gray100, gray800, green900, green700 } from '../../utils/colors';
 import { mobile } from '../../utils/media';
 
-const Receive = ({ config, currentAccount, setCurrentAccount }) => {
+const Receive = ({ config }) => {
   document.title = `Receive - Lily Wallet`;
   const [unusedAddressIndex, setUnusedAddressIndex] = useState(0);
-
+  const { setCurrentAccountId, currentAccount } = useContext(AccountMapContext);
   const { transactions, unusedAddresses, currentBalance } = currentAccount;
 
   return (
@@ -31,13 +33,21 @@ const Receive = ({ config, currentAccount, setCurrentAccount }) => {
       <ReceiveWrapper>
         <AccountMenu>
           {config.vaults.map((vault, index) => (
-            <AccountMenuItemWrapper key={index} active={vault.id === currentAccount.config.id} borderRight={(index < config.vaults.length - 1) || config.wallets.length} onClick={() => setCurrentAccount(vault.id)}>
+            <AccountMenuItemWrapper
+              key={index}
+              active={vault.id === currentAccount.config.id}
+              borderRight={(index < config.vaults.length - 1) || config.wallets.length}
+              onClick={() => setCurrentAccountId(vault.id)}>
               <StyledIcon as={Safe} size={48} />
               <AccountMenuItemName>{vault.name}</AccountMenuItemName>
             </AccountMenuItemWrapper>
           ))}
           {config.wallets.map((wallet, index) => (
-            <AccountMenuItemWrapper key={index} active={wallet.id === currentAccount.config.id} borderRight={(index < config.wallets.length - 1)} onClick={() => setCurrentAccount(wallet.id)}>
+            <AccountMenuItemWrapper
+              key={index}
+              active={wallet.id === currentAccount.config.id}
+              borderRight={(index < config.wallets.length - 1)}
+              onClick={() => setCurrentAccountId(wallet.id)}>
               <StyledIcon as={Wallet} size={48} />
               <AccountMenuItemName>{wallet.name}</AccountMenuItemName>
             </AccountMenuItemWrapper>

--- a/src/pages/Send/index.js
+++ b/src/pages/Send/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, Fragment } from 'react';
+import React, { useState, useRef, Fragment, useContext } from 'react';
 import styled, { css } from 'styled-components';
 import { Safe } from '@styled-icons/crypto';
 import { Wallet } from '@styled-icons/entypo';
@@ -15,6 +15,8 @@ import RecentTransactions from '../../components/transactions/RecentTransactions
 import SignWithDevice from './SignWithDevice'
 import TransactionDetails from './TransactionDetails';
 
+import { AccountMapContext } from '../../AccountMapContext';
+
 import { red, gray, green800, darkGray, white, darkOffWhite, gray100, black, lightGray } from '../../utils/colors';
 import { mobile } from '../../utils/media';
 import { cloneBuffer, bufferToHex } from '../../utils/other';
@@ -23,7 +25,7 @@ import { combinePsbts, bitcoinNetworkEqual } from '../../utils/files';
 import { createTransaction, validateAddress, createUtxoMapFromUtxoArray, getFee } from './utils'
 import { AddressDisplayWrapper, Input, InputStaticText } from './styles';
 
-const Send = ({ config, currentAccount, setCurrentAccount, toggleRefresh, currentBitcoinNetwork, currentBitcoinPrice }) => {
+const Send = ({ config, currentBitcoinNetwork, currentBitcoinPrice }) => {
   document.title = `Send - Lily Wallet`;
   const [sendAmount, setSendAmount] = useState('');
   const [sendAmountError, setSendAmountError] = useState(false);
@@ -42,6 +44,8 @@ const Send = ({ config, currentAccount, setCurrentAccount, toggleRefresh, curren
   const fileUploadLabelRef = useRef(null);
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [modalContent, setModalContent] = useState(null);
+
+  const { setCurrentAccountId, currentAccount } = useContext(AccountMapContext);
 
   // Get account data
   const { transactions, availableUtxos, unusedChangeAddresses, currentBalance } = currentAccount;
@@ -265,13 +269,20 @@ const Send = ({ config, currentAccount, setCurrentAccount, toggleRefresh, curren
   const SelectAccountMenu = () => (
     <AccountMenu>
       {config.vaults.map((vault, index) => (
-        <AccountMenuItemWrapper active={vault.id === currentAccount.config.id} borderRight={(index < config.vaults.length - 1) || config.wallets.length} onClick={() => setCurrentAccount(vault.id)}>
+        <AccountMenuItemWrapper
+          active={vault.id === currentAccount.config.id}
+          borderRight={(index < config.vaults.length - 1) || config.wallets.length}
+          onClick={() => setCurrentAccountId(vault.id)}>
           <StyledIcon as={Safe} size={48} />
           <AccountMenuItemName>{vault.name}</AccountMenuItemName>
         </AccountMenuItemWrapper>
       ))}
       {config.wallets.map((wallet, index) => (
-        <AccountMenuItemWrapper key={index} active={wallet.id === currentAccount.config.id} borderRight={(index < config.wallets.length - 1)} onClick={() => setCurrentAccount(wallet.id)}>
+        <AccountMenuItemWrapper
+          key={index}
+          active={wallet.id === currentAccount.config.id}
+          borderRight={(index < config.wallets.length - 1)}
+          onClick={() => setCurrentAccountId(wallet.id)}>
           <StyledIcon as={Wallet} size={48} />
           <AccountMenuItemName>{wallet.name}</AccountMenuItemName>
         </AccountMenuItemWrapper>

--- a/src/pages/Vault/index.js
+++ b/src/pages/Vault/index.js
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, Fragment } from 'react';
+import React, { useState, Fragment, useContext } from 'react';
 import { Link, useParams } from "react-router-dom";
 import styled from 'styled-components';
 import { VerticalAlignBottom, ArrowUpward, Settings, Refresh } from '@styled-icons/material';
 
+import { AccountMapContext } from '../../AccountMapContext';
 
 import { StyledIcon, Button, PageWrapper, PageTitle, Header, HeaderRight, HeaderLeft } from '../../components';
 
@@ -13,16 +14,14 @@ import VaultSettings from './VaultSettings';
 
 import { darkGray, gray100, gray400, gray500 } from '../../utils/colors';
 
-const Vault = ({ config, setConfigFile, password, toggleRefresh, currentAccount, setCurrentAccount, currentBitcoinNetwork }) => {
+const Vault = ({ config, setConfigFile, password, toggleRefresh, currentBitcoinNetwork }) => {
   document.title = `Vault - Lily Wallet`;
   const [viewSettings, setViewSettings] = useState(false);
   const [viewAddresses, setViewAddresses] = useState(false);
   const [viewUtxos, setViewUtxos] = useState(false);
   const { id } = useParams();
 
-  useEffect(() => {
-    setCurrentAccount(id)
-  }, [id, currentAccount, setCurrentAccount])
+  const { currentAccount } = useContext(AccountMapContext);
 
   const toggleViewSettings = () => {
     setViewSettings(!viewSettings);

--- a/src/reducers/accountMap.js
+++ b/src/reducers/accountMap.js
@@ -1,4 +1,3 @@
-
 export const ACCOUNTMAP_UPDATE = 'ACCOUNTMAP_UPDATE';
 export const ACCOUNTMAP_SET = 'ACCOUNTMAP_SET';
 


### PR DESCRIPTION
This refactors all the `accountMap` and `currentAccount` information to use Context instead of prop drilling from `App.js`.

As a side effect, it fixes a few UI bugs when initially loading in accountMap data at app startup and during data refreshing.